### PR TITLE
fix compatible old browser

### DIFF
--- a/parse.js
+++ b/parse.js
@@ -1,3 +1,5 @@
+"use strict";
+
 //https://gist.github.com/jonathangoncalves/7bdec924e9bd2bdf353d6b7520820b62
 //https://www.teleco.com.br/num.asp
 //https://forum.vivo.com.br/threads/52419-N%C3%BAmero-de-Celular-sem-come%C3%A7ar-com-quot-9-quot-ainda-existe
@@ -26,7 +28,9 @@ const default_options = {
 /**
  * @param {string} value número de telefone
  */
-module.exports = function (value, options = default_options){   
+module.exports = function (value, options){   
+    if (!options) options = default_options
+    
     if(value == null || typeof(value) !== 'string')
         return null;
 


### PR DESCRIPTION
"use strict";
// Uncaught SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
// let telefone = value.replace(/\D/g, '');

module.exports = function (value, options) {
    // Uncaught SyntaxError: Unexpected token =
    if (!options) options = default_options